### PR TITLE
Closes #39 - Bad namespace in the generated mixin

### DIFF
--- a/src/Manifests/ContainerMixinManifest.php
+++ b/src/Manifests/ContainerMixinManifest.php
@@ -161,7 +161,7 @@ class ContainerMixinManifest
 
         file_put_contents(
             $this->containerMixinPath,
-            "<?php namespace Xefi\\Faker\\Container{\n{$docComment}\n\tclass ContainerMixin{}"
+            "<?php namespace Xefi\\Faker\\Container;\n{$docComment}\n\tclass ContainerMixin{}"
         );
     }
 }

--- a/tests/Unit/ContainerMixinManifestTest.php
+++ b/tests/Unit/ContainerMixinManifestTest.php
@@ -61,6 +61,25 @@ final class ContainerMixinManifestTest extends TestCase
         unlink('/tmp/ContainerMixin.php');
     }
 
+    public function testContainerMixinNamespace()
+    {
+        @unlink('/tmp/ContainerMixin.php');
+        $container = new \Xefi\Faker\Container\Container(shouldBuildContainerMixin: false);
+        $manifest = new \Xefi\Faker\Manifests\ContainerMixinManifest(__DIR__.'/../Support', '/tmp/ContainerMixin.php');
+        $manifest->build($container->getExtensionMethods(), $container->getExtensions());
+
+        $this->assertFileExists('/tmp/ContainerMixin.php');
+
+        $containerMixinContent = file_get_contents('/tmp/ContainerMixin.php');
+
+        $this->assertStringContainsString(
+            'namespace Xefi\\Faker\\Container;',
+            $containerMixinContent
+        );
+
+        unlink('/tmp/ContainerMixin.php');
+    }
+
     public function testShouldRecompile()
     {
         @unlink('/tmp/ContainerMixin.php');


### PR DESCRIPTION
Closes #39 

Example of the generated mixin :

```
<?php namespace Xefi\Faker\Container;

/**
 * @function ...
 */
class ContainerMixin
{
}
```