### PR TITLE
Fix mixin characters

### DIFF
--- a/src/Manifests/ContainerMixinManifest.php
+++ b/src/Manifests/ContainerMixinManifest.php
@@ -7,7 +7,7 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Serializer;
 use phpDocumentor\Reflection\DocBlock\Tags\Method;
 use phpDocumentor\Reflection\TypeResolver;
-use phpDocumentor\Reflection\Types\Intersection;
+use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Reflection\Types\Nullable;
 
@@ -96,7 +96,7 @@ class ContainerMixinManifest
                     $type = $parameter->getType();
 
                     if ($type instanceof \ReflectionUnionType) {
-                        $type = new Intersection(
+                        $type = new Compound(
                             array_map(
                                 fn ($type) => $typeResolver->resolve($type),
                                 $type->getTypes()

--- a/tests/Support/Extensions/MixinTestExtension.php
+++ b/tests/Support/Extensions/MixinTestExtension.php
@@ -31,4 +31,9 @@ class MixinTestExtension extends Extension
     {
         return 'string';
     }
+
+    public function withCompoundType(int|string $param): int|string
+    {
+        return $param;
+    }
 }

--- a/tests/Unit/ContainerMixinManifestTest.php
+++ b/tests/Unit/ContainerMixinManifestTest.php
@@ -59,12 +59,12 @@ final class ContainerMixinManifestTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            '@method string|int withUnionType(string|int $param)',
+            '@method string|int withCompoundType(string|int $param)',
             $containerMixinContent
         );
 
         $this->assertStringNotContainsString(
-            '@method string|int withUnionType(string&int $param)',
+            '@method string|int withCompoundType(string&int $param)',
             $containerMixinContent
         );
 

--- a/tests/Unit/ContainerMixinManifestTest.php
+++ b/tests/Unit/ContainerMixinManifestTest.php
@@ -58,6 +58,16 @@ final class ContainerMixinManifestTest extends TestCase
             $containerMixinContent
         );
 
+        $this->assertStringContainsString(
+            '@method string|int withUnionType(string|int $param)',
+            $containerMixinContent
+        );
+
+        $this->assertStringNotContainsString(
+            '@method string|int withUnionType(string&int $param)',
+            $containerMixinContent
+        );
+
         unlink('/tmp/ContainerMixin.php');
     }
 


### PR DESCRIPTION
_This PR corrects the Mixin generation._

Previously, mixins were generated under the model :
`@method \DateTime dateTime(\DateTime&string&int $fromTimestamp = '-30 years', \DateTime&string&int $toTimestamp = 'now')`

Now the separator is correct:
`@method \DateTime dateTime(\DateTime|string|int $fromTimestamp = '-30 years', \DateTime|string|int $toTimestamp = 'now')`

**The problem was caused by the use of Intersection instead of Union Type. More information: https://php.watch/versions/8.1/intersection-types**

The phpDocumentor package renames the “Union type” to “Compound Type”.