### PR TITLE
Change mixin directory

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -48,7 +48,7 @@ class Container
      *
      * @var string
      */
-    protected static string $containerMixinManifestPath = './vendor/xefi/faker-php/src/Container/ContainerMixin.php';
+    protected static string $containerMixinManifestPath = './faker_mixin.php';
 
     /**
      * Create the container instance.

--- a/src/Extensions/ArrayExtension.php
+++ b/src/Extensions/ArrayExtension.php
@@ -17,4 +17,9 @@ class ArrayExtension extends Extension
     {
         return $this->pickArrayRandomKey($array);
     }
+
+    public function randomKeyNumber(array $array): mixed
+    {
+        return $this->pickArrayRandomKeyNumber($array);
+    }
 }

--- a/src/Extensions/Extension.php
+++ b/src/Extensions/Extension.php
@@ -67,6 +67,11 @@ class Extension
         return $this->randomizer->pickArrayKeys($array, $elements);
     }
 
+    protected function pickArrayRandomKeyNumber(array $array): mixed
+    {
+        return $this->pickArrayRandomKeys($array)[0];
+    }
+
     protected function pickArrayRandomKey(array $array): mixed
     {
         return key($array[$this->pickArrayRandomKeys($array)[0]]);

--- a/src/Extensions/Extension.php
+++ b/src/Extensions/Extension.php
@@ -69,7 +69,7 @@ class Extension
 
     protected function pickArrayRandomKey(array $array): mixed
     {
-        return $this->pickArrayRandomKeys($array)[0];
+        return key($array[$this->pickArrayRandomKeys($array)[0]]);
     }
 
     protected function formatString(string $string): string

--- a/src/Manifests/ContainerMixinManifest.php
+++ b/src/Manifests/ContainerMixinManifest.php
@@ -44,7 +44,7 @@ class ContainerMixinManifest
     {
         $this->basePath = $basePath;
         $this->vendorPath = $basePath.'/vendor';
-        $this->containerMixinPath = $containerMixinPath ?? $basePath.'/vendor/xefi/faker-php/src/Container/ContainerMixin.php';
+        $this->containerMixinPath = $containerMixinPath ?? $basePath.'/faker_mixin.php';
     }
 
     /**

--- a/tests/Unit/ExtensionTest.php
+++ b/tests/Unit/ExtensionTest.php
@@ -93,7 +93,7 @@ class ExtensionTest extends TestCase
             'e' => 5,
         ];
 
-        $method = (new ReflectionClass(Extension::class))->getMethod('pickArrayRandomKey');
+        $method = (new ReflectionClass(Extension::class))->getMethod('pickArrayRandomKeyNumber');
         $result = $method->invoke(new Extension(new Randomizer()), $elements);
 
         $this->assertArrayHasKey($result, $elements);

--- a/tests/Unit/Extensions/ArraysExtensionTest.php
+++ b/tests/Unit/Extensions/ArraysExtensionTest.php
@@ -23,11 +23,11 @@ final class ArraysExtensionTest extends TestCase
         $this->assertEqualsCanonicalizing($elements, $this->testArray);
     }
 
-    public function testRandomKey(): void
+    public function testRandomKeyNumber(): void
     {
         $elements = [];
         for ($i = 0; $i < count($this->testArray); $i++) {
-            $elements[] = $this->faker->unique()->randomKey($this->testArray);
+            $elements[] = $this->faker->unique()->randomKeyNumber($this->testArray);
         }
 
         $this->assertEqualsCanonicalizing($elements, array_keys($this->testArray));

--- a/tests/Unit/Extensions/ArraysExtensionTest.php
+++ b/tests/Unit/Extensions/ArraysExtensionTest.php
@@ -2,6 +2,8 @@
 
 namespace Xefi\Faker\Tests\Unit\Extensions;
 
+use Random\Randomizer;
+
 final class ArraysExtensionTest extends TestCase
 {
     protected array $testArray = [];
@@ -31,5 +33,18 @@ final class ArraysExtensionTest extends TestCase
         }
 
         $this->assertEqualsCanonicalizing($elements, array_keys($this->testArray));
+    }
+
+    public function testRandomKey(): void
+    {
+        $inputArray = [
+            ['firstname' => 'John'],
+            ['lastname' => 'Doe'],
+            ['nickname' => 'Johnny'],
+            ['login' => 'j.doe']
+        ];
+
+        $result = $this->faker->randomKey($inputArray);
+        $this->assertContains($result, ['firstname', 'lastname', 'nickname', 'login']);
     }
 }


### PR DESCRIPTION
Close #42 
This PR changes the mixin location.
In the same way as ide helper, for example, mixin are present at the root of the project, and no longer in the vendors.
The file is now called `_faker_mixin.php`, let me know if the name doesn't work. 

The tests do not require any updates.