### PR TITLE
Add multibyte support to case modifiers and tests

### DIFF
--- a/src/Modifiers/LowercaseModifier.php
+++ b/src/Modifiers/LowercaseModifier.php
@@ -14,6 +14,12 @@ class LowercaseModifier extends Modifier
     public function apply(mixed $generatedValue): mixed
     {
         if (is_string($generatedValue)) {
+            if (function_exists('mb_strtolower')) {
+                return mb_strtolower($generatedValue);
+            }
+
+            trigger_error('You do not have the `mbstring` extension enable, FakerPHP might not handle not common characters.', E_USER_WARNING);
+
             return strtolower($generatedValue);
         }
 

--- a/src/Modifiers/UppercaseModifier.php
+++ b/src/Modifiers/UppercaseModifier.php
@@ -14,6 +14,12 @@ class UppercaseModifier extends Modifier
     public function apply(mixed $generatedValue): mixed
     {
         if (is_string($generatedValue)) {
+            if (function_exists('mb_strtoupper')) {
+                return mb_strtoupper($generatedValue);
+            }
+
+            trigger_error('You do not have the `mbstring` extension enable, FakerPHP might not handle not common characters.', E_USER_WARNING);
+
             return strtoupper($generatedValue);
         }
 

--- a/tests/Support/Extensions/StringTestExtension.php
+++ b/tests/Support/Extensions/StringTestExtension.php
@@ -15,4 +15,14 @@ class StringTestExtension extends Extension
     {
         return 'HELLO';
     }
+
+    public function returnAccentsLowercase()
+    {
+        return 'éèàùâêîôûëïüç';
+    }
+
+    public function returnAccentsUppercase()
+    {
+        return 'ÉÈÀÙÂÊÎÔÛËÏÜÇ';
+    }
 }

--- a/tests/Unit/Modifiers/LowercaseModifierTest.php
+++ b/tests/Unit/Modifiers/LowercaseModifierTest.php
@@ -29,4 +29,14 @@ class LowercaseModifierTest extends TestCase
             $faker->lowercase()->returnHelloUppercase(),
         );
     }
+
+    public function testLowercaseModifierWithAccent(): void
+    {
+        $faker = new Faker();
+
+        $this->assertEquals(
+            'éèàùâêîôûëïüç',
+            $faker->lowercase()->returnAccentsUppercase()
+        );
+    }
 }

--- a/tests/Unit/Modifiers/UppercaseModifierTest.php
+++ b/tests/Unit/Modifiers/UppercaseModifierTest.php
@@ -29,4 +29,14 @@ class UppercaseModifierTest extends TestCase
             $faker->uppercase()->returnHello()
         );
     }
+
+    public function testUppercaseModifierWithAccent(): void
+    {
+        $faker = new Faker();
+
+        $this->assertEquals(
+            'ÉÈÀÙÂÊÎÔÛËÏÜÇ',
+            $faker->uppercase()->returnAccentsLowercase()
+        );
+    }
 }


### PR DESCRIPTION
LowercaseModifier and UppercaseModifier now use mbstring functions when available to handle accented characters correctly, with a warning if mbstring is missing. Added tests for accented character case conversion to ensure proper behavior.

closes #51 