### PR TITLE
Generate mixin after composer install/update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,16 @@
         "Xefi\\Faker\\FakerServiceProvider"
       ]
     }
+  },
+  "scripts": {
+    "post-install-cmd": [
+      "composer run generate-mixin"
+    ],
+    "post-update-cmd": [
+      "composer run generate-mixin"
+    ],
+    "generate-mixin": [
+      "php -r 'require \"vendor/autoload.php\"; (new Xefi\\Faker\\Container\\Container());'"
+    ]
   }
 }


### PR DESCRIPTION
This will generate the mixin during the installation of the package and get the autocompletion in the IDE.

I'm currently looking if xefi/faker-php-laravel & xefi/faker-php-symfony are compatible with what I've done before submiting the PR.