### PR TITLE
Allow reflection-docblock v6 & fix mixin generation in Windows

### DIFF
--- a/.github/workflows/packagist-deploy.yml
+++ b/.github/workflows/packagist-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: mnavarrocarter/packagist-update@v1.0.0
         with:
           username: "GautierDele"

--- a/.github/workflows/packagist-deploy.yml
+++ b/.github/workflows/packagist-deploy.yml
@@ -2,7 +2,7 @@ name: Packagist Deploy
 
 on:
   release:
-    types: [created]
+    types: [ created ]
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.3', '8.4', '8.5' ]
+        php-version: [ "8.3", "8.4", "8.5" ]
 
     name: Tests on PHP ${{ matrix.php-version }}
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer i --prefer-dist --no-progress
+        run: composer i --no-progress
 
       - name: Run test suite
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -33,7 +33,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 composer.lock
 .phpunit*
 .idea
+faker_mixin.php
+packages.php

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You'll be able to generate fake data for your applications, making your test env
 Here is a quick look at what you can do:
 
 ```php
-$faker = new Xefi\Faker\Faker();
+$faker = new \Xefi\Faker\Faker();
 
 $faker->name() // John Doe
 $faker->name() // Charles Brown

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     }
   },
   "config": {
+    "optimize-autoloader": true,
     "sort-packages": true
   },
   "extra": {
@@ -53,7 +54,7 @@
       "composer run generate-mixin"
     ],
     "generate-mixin": [
-      "@php -r 'require \"vendor/autoload.php\"; (new Xefi\\Faker\\Container\\Container());'"
+      "@php -r \"require 'vendor/autoload.php'; (new Xefi\\Faker\\Container\\Container());\""
     ],
     "test": [
       "@php vendor/bin/phpunit --colors=always"

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
   },
   "config": {
     "optimize-autoloader": true,
+    "preferred-install": "dist",
     "sort-packages": true
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": ">=8.3 <8.6",
-    "phpdocumentor/reflection-docblock": "^5.6",
+    "phpdocumentor/reflection-docblock": "^5.6|^6.0",
     "psr/container": "^2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -53,10 +53,10 @@
       "composer run generate-mixin"
     ],
     "generate-mixin": [
-      "php -r 'require \"vendor/autoload.php\"; (new Xefi\\Faker\\Container\\Container());'"
+      "@php -r 'require \"vendor/autoload.php\"; (new Xefi\\Faker\\Container\\Container());'"
     ],
     "test": [
-      "php vendor/bin/phpunit --colors=always"
+      "@php vendor/bin/phpunit --colors=always"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,6 @@
       "Xefi\\Faker\\Tests\\": "tests/"
     }
   },
-  "config": {
-    "optimize-autoloader": true,
-    "preferred-install": "dist",
-    "sort-packages": true
-  },
   "extra": {
     "faker": {
       "providers": [
@@ -49,16 +44,27 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "composer run generate-mixin"
+      "@composer run generate-mixin"
     ],
     "post-update-cmd": [
-      "composer run generate-mixin"
+      "@composer run generate-mixin"
     ],
     "generate-mixin": [
-      "@php -r \"require 'vendor/autoload.php'; (new Xefi\\Faker\\Container\\Container());\""
+      "@php scripts/generate-mixin.php"
     ],
     "test": [
       "@php vendor/bin/phpunit --colors=always"
     ]
-  }
+  },
+  "scripts-descriptions": {
+    "test": "Run the PHPUnit tests.",
+    "generate-mixin": "Generates the IDE mixin during package installation to enable autocompletion support."
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": "dist",
+    "sort-packages": true
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "psr/container": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^11"
+    "phpunit/phpunit": "^12.5.23"
   },
   "autoload": {
     "psr-4": {
@@ -54,6 +54,9 @@
     ],
     "generate-mixin": [
       "php -r 'require \"vendor/autoload.php\"; (new Xefi\\Faker\\Container\\Container());'"
+    ],
+    "test": [
+      "php vendor/bin/phpunit --colors=always"
     ]
   }
 }

--- a/scripts/generate-mixin.php
+++ b/scripts/generate-mixin.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Script to generate the IDE mixin for Xefi/Faker.
+ *
+ * This file is executed during Composer install/update via the "generate-mixin" script.
+ * It bootstraps the autoloader and instantiates the Xefi\Faker\Container\Container,
+ * which produces the mixin file used by supported IDEs to enable autocompletion.
+ *
+ * Running this ensures that developers get proper type hints and code completion
+ * when working with xefi/faker-php in their projects.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+new \Xefi\Faker\Container\Container;

--- a/scripts/generate-mixin.php
+++ b/scripts/generate-mixin.php
@@ -11,6 +11,6 @@
  * when working with xefi/faker-php in their projects.
  */
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
-new \Xefi\Faker\Container\Container;
+new \Xefi\Faker\Container\Container();

--- a/tests/Unit/Extensions/GeographicalExtensionTest.php
+++ b/tests/Unit/Extensions/GeographicalExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Extensions;
+namespace Xefi\Faker\Tests\Unit\Extensions;
 
 use Xefi\Faker\Tests\Unit\Extensions\TestCase;
 

--- a/tests/Unit/Extensions/GeographicalExtensionTest.php
+++ b/tests/Unit/Extensions/GeographicalExtensionTest.php
@@ -2,8 +2,6 @@
 
 namespace Xefi\Faker\Tests\Unit\Extensions;
 
-use Xefi\Faker\Tests\Unit\Extensions\TestCase;
-
 final class GeographicalExtensionTest extends TestCase
 {
     public function testLatitude(): void

--- a/tests/Unit/LocaleTest.php
+++ b/tests/Unit/LocaleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Xefi\Faker\Tests\Unit;
+
 class LocaleTest extends \Xefi\Faker\Tests\Unit\TestCase
 {
     protected function setUp(): void
@@ -39,7 +41,7 @@ class LocaleTest extends \Xefi\Faker\Tests\Unit\TestCase
 
     public function testUsingDefaultLocale()
     {
-        $faker = new Xefi\Faker\Faker('fr_FR');
+        $faker = new \Xefi\Faker\Faker('fr_FR');
         $this->assertEquals(
             'fr_FR',
             $faker->returnLocale()
@@ -68,7 +70,7 @@ class LocaleTest extends \Xefi\Faker\Tests\Unit\TestCase
 
     public function testResettingLocale()
     {
-        $faker = new Xefi\Faker\Faker('fr_FR');
+        $faker = new \Xefi\Faker\Faker('fr_FR');
         $this->assertEquals(
             'fr_FR',
             $faker->returnLocale()
@@ -87,7 +89,7 @@ class LocaleTest extends \Xefi\Faker\Tests\Unit\TestCase
 
     public function testUsingNotExistingLocaleFallingBackToNullLocale()
     {
-        $faker = new Xefi\Faker\Faker('not-existing-locale');
+        $faker = new \Xefi\Faker\Faker('not-existing-locale');
         $this->assertEquals(
             'default',
             $faker->returnLocale()
@@ -108,7 +110,7 @@ class LocaleTest extends \Xefi\Faker\Tests\Unit\TestCase
         $this->expectException(\Xefi\Faker\Exceptions\NoExtensionLocaleFound::class);
         $this->expectExceptionMessage('Locale \'not-existing-locale\' and \'default\' for method \'returnLocale\' was not found');
 
-        $faker = new Xefi\Faker\Faker('not-existing-locale');
+        $faker = new \Xefi\Faker\Faker('not-existing-locale');
         $faker->returnLocale();
     }
 }

--- a/tests/Unit/PackageManifestTest.php
+++ b/tests/Unit/PackageManifestTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Xefi\Faker\Tests\Unit;
+
 use Xefi\Faker\Manifests\PackageManifest;
 use Xefi\Faker\Tests\Unit\TestCase;
 

--- a/tests/Unit/PackageManifestTest.php
+++ b/tests/Unit/PackageManifestTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Xefi\Faker\Tests\Unit;
 
 use Xefi\Faker\Manifests\PackageManifest;
-use Xefi\Faker\Tests\Unit\TestCase;
 
 final class PackageManifestTest extends TestCase
 {

--- a/tests/Unit/ProviderRepositoryTest.php
+++ b/tests/Unit/ProviderRepositoryTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Xefi\Faker\Tests\Unit;
+
 use Xefi\Faker\Tests\Unit\TestCase;
 
 final class ProviderRepositoryTest extends TestCase

--- a/tests/Unit/ProviderRepositoryTest.php
+++ b/tests/Unit/ProviderRepositoryTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Xefi\Faker\Tests\Unit;
 
-use Xefi\Faker\Tests\Unit\TestCase;
-
 final class ProviderRepositoryTest extends TestCase
 {
     public function testCreateProvider()

--- a/tests/Unit/Strategies/ValidStrategyTest.php
+++ b/tests/Unit/Strategies/ValidStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Strategies;
+namespace Xefi\Faker\Tests\Unit\Strategies;
 
 use Xefi\Faker\Faker;
 use Xefi\Faker\Strategies\ValidStrategy;


### PR DESCRIPTION
This PR updates `composer.json` to allow `reflection-docblock` v6, with range `"phpdocumentor/reflection-docblock": "^5.6|^6.0"`, no breaking changes.

#### Also does some cleaning:

- Update workflow actions to latest (fixes warning `Node.js 20 actions are deprecated`)
- Exclude autogenerated (and uncommitted) files in .gitignore, `faker_mixin.php` and `packages.php`
- Upgrade `phpunit` to v12, which requires `php >= 8.3`, same as current supported php version, and receives bugfixes until February 5, 2027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI actions for improved stability.
  * Adjusted project ignores and build optimization.

* **Tests**
  * Upgraded testing framework and added a simplified test script.
  * Reorganized test namespaces for clearer structure.

* **Documentation**
  * Clarified README example to use fully-qualified class instantiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->