### PR TITLE
Handle the DateTimeImmutable class.

### DIFF
--- a/src/Extensions/DateTimeExtension.php
+++ b/src/Extensions/DateTimeExtension.php
@@ -3,6 +3,8 @@
 namespace Xefi\Faker\Extensions;
 
 use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
 
 class DateTimeExtension extends Extension
 {
@@ -38,25 +40,30 @@ class DateTimeExtension extends Extension
         'America/Toronto',
     ];
 
-    protected function formatTimestamp(DateTime|int|string $timestamp): int
+    protected function formatTimestamp(DateTimeInterface|int|string $timestamp): int
     {
         if (is_int($timestamp)) {
             return $timestamp;
         }
 
-        if ($timestamp instanceof DateTime) {
+        if ($timestamp instanceof DateTimeInterface) {
             return $timestamp->getTimestamp();
         }
 
         return strtotime($timestamp);
     }
 
-    public function dateTime(DateTime|int|string $fromTimestamp = '-30 years', DateTime|int|string $toTimestamp = 'now'): DateTime
+    public function dateTime(DateTimeInterface|int|string $fromTimestamp = '-30 years', DateTimeInterface|int|string $toTimestamp = 'now'): DateTime
     {
         return new DateTime('@'.$this->timestamp($fromTimestamp, $toTimestamp));
     }
 
-    public function timestamp(DateTime|int|string $fromTimestamp = '-30 years', DateTime|int|string $toTimestamp = 'now'): int
+    public function dateTimeImmutable(DateTimeInterface|int|string $fromTimestamp = '-30 years', DateTimeInterface|int|string $toTimestamp = 'now'): DateTimeImmutable
+    {
+        return new DateTimeImmutable('@'.$this->timestamp($fromTimestamp, $toTimestamp));
+    }
+
+    public function timestamp(DateTimeInterface|int|string $fromTimestamp = '-30 years', DateTimeInterface|int|string $toTimestamp = 'now'): int
     {
         return $this->randomizer->getInt($this->formatTimestamp($fromTimestamp), $this->formatTimestamp($toTimestamp));
     }

--- a/tests/Unit/Extensions/DatetimeExtensionTest.php
+++ b/tests/Unit/Extensions/DatetimeExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Xefi\Faker\Tests\Unit\Extensions;
 
 use DateTime;
+use DateTimeImmutable;
 
 final class DatetimeExtensionTest extends TestCase
 {
@@ -71,6 +72,25 @@ final class DatetimeExtensionTest extends TestCase
         $toDateTime = new DateTime('now');
 
         foreach ($results as $result) {
+            $this->assertInstanceOf(DateTime::class, $result);
+            $this->assertGreaterThanOrEqual($fromDateTime->getTimestamp(), $result->getTimestamp());
+            $this->assertLessThanOrEqual($toDateTime->getTimestamp(), $result->getTimestamp());
+        }
+    }
+
+    public function testDateTimeImmutable(): void
+    {
+        $results = [];
+
+        for ($i = 0; $i < 50; $i++) {
+            $results[] = $this->faker->dateTimeImmutable('-30 years', 'now');
+        }
+
+        $fromDateTime = new DateTimeImmutable('-30 years');
+        $toDateTime = new DateTimeImmutable('now');
+
+        foreach ($results as $result) {
+            $this->assertInstanceOf(DateTimeImmutable::class, $result);
             $this->assertGreaterThanOrEqual($fromDateTime->getTimestamp(), $result->getTimestamp());
             $this->assertLessThanOrEqual($toDateTime->getTimestamp(), $result->getTimestamp());
         }


### PR DESCRIPTION
Add the support of `DateTimeImmutable` class in the `DateTimeExtension`. Both as a valid argument for `formatTimestamp`, `dateTime`, and `timestamp` existing methods, plus an additional `dateTimeImmutable`. This is a must have feature for projects that prefer `DateTimeImmutable` over `DateTime` and it fix a known issue of the old `FakerPHP` implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating immutable date-time values alongside the existing mutable date-time output.
  * Expanded date-time handling to accept a wider range of time input types.

* **Bug Fixes**
  * Improved timestamp processing so date-time-related values are handled more consistently across supported inputs.

* **Tests**
  * Updated coverage to verify immutable date-time results and confirm generated timestamps stay within the expected range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->