### PR TITLE
Let the user build its own randomizer engine to fix the seed and get reproductible results.

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -3,6 +3,7 @@
 namespace Xefi\Faker\Container;
 
 use Closure;
+use Random\Engine;
 use Xefi\Faker\Container\Traits\HasExtensions;
 use Xefi\Faker\Container\Traits\HasLocale;
 use Xefi\Faker\Container\Traits\HasModifiers;
@@ -48,12 +49,19 @@ class Container
     protected static string $containerMixinManifestPath = './faker_mixin.php';
 
     /**
+     * @var Engine|null
+     */
+    private ?Engine $engine;
+
+    /**
      * Create the container instance.
      *
      * @return void
      */
-    public function __construct(bool $shouldBuildContainerMixin = true)
+    public function __construct(?Engine $engine = null, bool $shouldBuildContainerMixin = true)
     {
+        $this->engine = $engine;
+
         if (!$this->areExtensionsInitialized()) {
             $this->registerConfiguredProviders();
 
@@ -99,6 +107,14 @@ class Container
     public static function basePath(string $basePath)
     {
         static::$basePath = $basePath;
+    }
+
+    /**
+     * @return Engine|null
+     */
+    public function getEngine(): ?Engine
+    {
+        return $this->engine;
     }
 
     /**

--- a/src/Container/Traits/HasExtensions.php
+++ b/src/Container/Traits/HasExtensions.php
@@ -2,6 +2,7 @@
 
 namespace Xefi\Faker\Container\Traits;
 
+use Random\Engine;
 use Random\Randomizer;
 use Xefi\Faker\Container\Container;
 use Xefi\Faker\Container\Enum\Locales;
@@ -27,14 +28,15 @@ trait HasExtensions
     /**
      * Resolve an array of extensions through the container.
      *
-     * @param array $extensions
+     * @param array       $extensions
+     * @param Engine|null $engine
      *
      * @return $this
      */
-    public function resolveExtensions(array $extensions): self
+    public function resolveExtensions(array $extensions, ?Engine $engine = null): self
     {
         foreach ($extensions as $extension) {
-            $this->resolve($extension);
+            $this->resolve($extension, $engine);
         }
 
         return $this;
@@ -44,12 +46,13 @@ trait HasExtensions
      * Add an extension, resolving through the application.
      *
      * @param Extension|string $extension
+     * @param Engine|null      $engine
      *
      * @return Container
      */
-    protected function resolve(\Xefi\Faker\Extensions\Extension|string $extension): Container
+    protected function resolve(\Xefi\Faker\Extensions\Extension|string $extension, ?Engine $engine = null): Container
     {
-        $instance = $extension instanceof Extension ? $extension : new $extension(new Randomizer());
+        $instance = $extension instanceof Extension ? $extension : new $extension(new Randomizer($engine));
 
         // If the extension supports locale variations
         if (method_exists($instance, 'getLocale')) {

--- a/src/Container/Traits/HasModifiers.php
+++ b/src/Container/Traits/HasModifiers.php
@@ -27,7 +27,7 @@ trait HasModifiers
      */
     public function nullable(int $weight = 50): self
     {
-        $this->modifiers[] = new NullableModifier(new Randomizer(), $weight);
+        $this->modifiers[] = new NullableModifier(new Randomizer($this->engine), $weight);
 
         return $this;
     }

--- a/src/Extensions/Extension.php
+++ b/src/Extensions/Extension.php
@@ -9,7 +9,7 @@ class Extension
 {
     protected Randomizer $randomizer;
 
-    public function __construct(Randomizer $randomizer)
+    final public function __construct(Randomizer $randomizer)
     {
         $this->randomizer = $randomizer;
     }

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -2,6 +2,7 @@
 
 namespace Xefi\Faker;
 
+use Random\Engine;
 use Xefi\Faker\Container\Container;
 
 /**
@@ -16,14 +17,22 @@ class Faker
      */
     protected ?string $locale;
 
-    public function __construct(?string $locale = null)
+    /**
+     * The current Randomizer engine.
+     *
+     * @var Engine|null
+     */
+    protected ?Engine $engine;
+
+    public function __construct(?string $locale = null, ?Engine $engine = null)
     {
         $this->locale = $locale;
+        $this->engine = $engine;
     }
 
     public function __call(string $method, array $parameters)
     {
         // We simply redirect calls to container to create a new container for each faker call
-        return (new Container())->locale($this->locale)->{$method}(...$parameters);
+        return (new Container($this->engine))->locale($this->locale)->{$method}(...$parameters);
     }
 }

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -16,7 +16,7 @@ class Provider
     public function extensions(array $extensions)
     {
         Container::starting(function (Container $container) use ($extensions) {
-            $container->resolveExtensions($extensions);
+            $container->resolveExtensions($extensions, $container->getEngine());
         });
     }
 

--- a/tests/Support/Extensions/NumberTestExtension.php
+++ b/tests/Support/Extensions/NumberTestExtension.php
@@ -13,6 +13,6 @@ class NumberTestExtension extends Extension
 
     public function returnNumberBetween($min, $max)
     {
-        return rand($min, $max);
+        return $this->randomizer->getInt($min, $max);
     }
 }

--- a/tests/Unit/Extensions/HashExtensionTest.php
+++ b/tests/Unit/Extensions/HashExtensionTest.php
@@ -11,11 +11,27 @@ final class HashExtensionTest extends TestCase
         $this->assertMatchesRegularExpression('/^[a-z0-9]{40}$/', $result);
     }
 
+    public function testSha1IsSeedable(): void
+    {
+        $this->assertEquals(
+            $this->createFresh()->sha1(),
+            $this->createFresh()->sha1(),
+        );
+    }
+
     public function testSha256(): void
     {
         $result = $this->faker->sha256();
 
         $this->assertMatchesRegularExpression('/^[a-z0-9]{64}$/', $result);
+    }
+
+    public function testSha256IsSeedable(): void
+    {
+        $this->assertEquals(
+            $this->createFresh()->sha256(),
+            $this->createFresh()->sha256(),
+        );
     }
 
     public function testSha512(): void
@@ -25,10 +41,26 @@ final class HashExtensionTest extends TestCase
         $this->assertMatchesRegularExpression('/^[a-z0-9]{128}$/', $result);
     }
 
+    public function testSha512IsSeedable(): void
+    {
+        $this->assertEquals(
+            $this->createFresh()->sha512(),
+            $this->createFresh()->sha512(),
+        );
+    }
+
     public function testMd5(): void
     {
         $result = $this->faker->md5();
 
         $this->assertMatchesRegularExpression('/^[a-fA-F0-9]{32}$/', $result);
+    }
+
+    public function testMd5IsSeedable(): void
+    {
+        $this->assertEquals(
+            $this->createFresh()->md5(),
+            $this->createFresh()->md5(),
+        );
     }
 }

--- a/tests/Unit/Extensions/InternetExtensionTest.php
+++ b/tests/Unit/Extensions/InternetExtensionTest.php
@@ -19,7 +19,7 @@ final class InternetExtensionTest extends TestCase
 
     public function testSdl(): void
     {
-        $faker = new Container(false);
+        $faker = new Container(null, false);
 
         $results = [];
 
@@ -34,7 +34,7 @@ final class InternetExtensionTest extends TestCase
 
     public function testTld(): void
     {
-        $faker = new Container(false);
+        $faker = new Container(null, false);
 
         $results = [];
 
@@ -47,7 +47,7 @@ final class InternetExtensionTest extends TestCase
 
     public function testDomain(): void
     {
-        $faker = new Container(false);
+        $faker = new Container(null, false);
 
         $results = [];
 
@@ -62,7 +62,7 @@ final class InternetExtensionTest extends TestCase
 
     public function testIp(): void
     {
-        $faker = new Container(false);
+        $faker = new Container(null, false);
 
         for ($i = 0; $i < 50; $i++) {
             $result = $faker->ip();
@@ -73,7 +73,7 @@ final class InternetExtensionTest extends TestCase
 
     public function testIpv4(): void
     {
-        $faker = new Container(false);
+        $faker = new Container(null, false);
 
         $results = [];
 
@@ -88,7 +88,7 @@ final class InternetExtensionTest extends TestCase
 
     public function testIpv6(): void
     {
-        $faker = new Container(false);
+        $faker = new Container(null, false);
 
         $results = [];
 
@@ -103,7 +103,7 @@ final class InternetExtensionTest extends TestCase
 
     public function testMacAddress(): void
     {
-        $faker = new Container(false);
+        $faker = new Container(null, false);
 
         $results = [];
 
@@ -118,7 +118,7 @@ final class InternetExtensionTest extends TestCase
 
     public function testEmail(): void
     {
-        $faker = new Container(false);
+        $faker = new Container(null, false);
 
         $results = [];
 

--- a/tests/Unit/Extensions/TestCase.php
+++ b/tests/Unit/Extensions/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Xefi\Faker\Tests\Unit\Extensions;
 
+use Random\Engine\Mt19937;
 use Xefi\Faker\Container\Container;
 use Xefi\Faker\FakerServiceProvider;
 
@@ -15,6 +16,18 @@ class TestCase extends \Xefi\Faker\Tests\Unit\TestCase
 
         (new FakerServiceProvider())->boot();
 
-        $this->faker = new Container(false);
+        $this->faker = new Container(new Mt19937(19937), false);
+    }
+
+    protected function createFresh(): Container
+    {
+        $this->faker->forgetBootstrappers();
+        $this->faker->forgetExtensions();
+        $this->faker->forgetModifiers();
+        $this->faker->forgetStrategies();
+
+        (new FakerServiceProvider())->boot();
+
+        return new Container(new Mt19937(19937), false);
     }
 }


### PR DESCRIPTION
Sometimes, its useful to fix a random seed to get reproductible results. However, its not possible yet. This PR tries to address this issue.

I would also love to discuss the static nature of things because it is harder to have two Faker instances at the same time. Its not that much desirable, but force the consumer to do weird reset things to fix the seed. This can be seen on the extension TestCase I changed for this purpose.

If this PR goes further, I will gladly make a PR to the documentation project too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for providing a custom random engine when creating faker instances and containers.
  * Random-dependent features can now produce repeatable results when initialized with the same engine.

* **Bug Fixes**
  * Improved consistency in generated values by using the shared engine for extensions, modifiers, and provider resolution.
  * Updated test setup to use deterministic random behavior for more stable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->