### PR TITLE
Discover providers from the project itself.

### DIFF
--- a/src/Manifests/ContainerMixinManifest.php
+++ b/src/Manifests/ContainerMixinManifest.php
@@ -120,8 +120,8 @@ class ContainerMixinManifest
 
             $tags[] = new Method(
                 $methodName,
-                returnType: $reflectionMethod->hasReturnType() ? (new TypeResolver())->resolve($reflectionMethod->getReturnType()) : new Mixed_(),
                 parameters: $parameters,
+                returnType: $reflectionMethod->hasReturnType() ? (new TypeResolver())->resolve($reflectionMethod->getReturnType()) : new Mixed_(),
             );
         }
 
@@ -142,8 +142,9 @@ class ContainerMixinManifest
     public function shouldRecompile(): bool
     {
         return !is_file($this->containerMixinPath) ||
-            // We check here if the manifest has been generated before changing the installed.json composer file
-            filemtime($this->containerMixinPath) <= filemtime($this->vendorPath.'/composer/installed.json');
+            // We check here if the manifest has been generated before changing the installed.json composer file or the project composer.json
+            filemtime($this->containerMixinPath) <= filemtime($this->vendorPath.'/composer/installed.json') ||
+            filemtime($this->containerMixinPath) <= filemtime($this->basePath.'/composer.json');
     }
 
     /**

--- a/src/Manifests/PackageManifest.php
+++ b/src/Manifests/PackageManifest.php
@@ -120,6 +120,14 @@ class PackageManifest
             }
         }
 
+        if (is_file($path = $this->basePath.'/composer.json')) {
+            $package = json_decode(file_get_contents($path), true);
+
+            if (isset($package['extra']['faker'])) {
+                $packagesToProvide[$package['name'] ?? 'root'] = $package['extra']['faker'];
+            }
+        }
+
         $this->write(
             $packagesToProvide
         );
@@ -133,8 +141,9 @@ class PackageManifest
     public function shouldRecompile(): bool
     {
         return !is_file($this->manifestPath) ||
-            // We check here if the manifest has been generated before changing the installed.json composer file
-            filemtime($this->manifestPath) <= filemtime($this->vendorPath.'/composer/installed.json');
+            // We check here if the manifest has been generated before changing the installed.json composer file or the project composer.json
+            filemtime($this->manifestPath) <= filemtime($this->vendorPath.'/composer/installed.json') ||
+            filemtime($this->manifestPath) <= filemtime($this->basePath.'/composer.json');
     }
 
     /**

--- a/tests/Support/Concerns/CreatesTemporaryProjects.php
+++ b/tests/Support/Concerns/CreatesTemporaryProjects.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Xefi\Faker\Tests\Support\Concerns;
+
+trait CreatesTemporaryProjects
+{
+    /**
+     * The temporary project paths created during the test.
+     *
+     * @var array
+     */
+    private array $temporaryProjectPaths = [];
+
+    /**
+     * Create a temporary project directory holding an installed.json and,
+     * when given, a root composer.json.
+     *
+     * @param ?array $composer
+     * @param array  $installedPackages
+     *
+     * @return string
+     */
+    private function createTemporaryProject(?array $composer = null, array $installedPackages = []): string
+    {
+        $projectPath = sys_get_temp_dir().'/faker-php-'.uniqid();
+
+        mkdir($projectPath.'/vendor/composer', 0777, true);
+
+        file_put_contents(
+            $projectPath.'/vendor/composer/installed.json',
+            json_encode(['packages' => $installedPackages])
+        );
+
+        if ($composer !== null) {
+            file_put_contents($projectPath.'/composer.json', json_encode($composer));
+        }
+
+        $this->temporaryProjectPaths[] = $projectPath;
+
+        return $projectPath;
+    }
+
+    /**
+     * Remove every temporary project created during the test.
+     *
+     * @return void
+     */
+    private function deleteTemporaryProjects(): void
+    {
+        foreach ($this->temporaryProjectPaths as $projectPath) {
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($projectPath, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+
+            foreach ($files as $file) {
+                $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+            }
+
+            rmdir($projectPath);
+        }
+
+        $this->temporaryProjectPaths = [];
+    }
+}

--- a/tests/Support/composer.json
+++ b/tests/Support/composer.json
@@ -1,0 +1,3 @@
+{
+  "name": "xefi/faker-php-tests-support"
+}

--- a/tests/Unit/ContainerMixinManifestTest.php
+++ b/tests/Unit/ContainerMixinManifestTest.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Xefi\Faker\Tests\Unit;
 
+use Xefi\Faker\Tests\Support\Concerns\CreatesTemporaryProjects;
+
 final class ContainerMixinManifestTest extends TestCase
 {
+    use CreatesTemporaryProjects;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -15,6 +19,13 @@ final class ContainerMixinManifestTest extends TestCase
         $container->resolveExtensions([
             \Xefi\Faker\Tests\Support\Extensions\MixinTestExtension::class,
         ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTemporaryProjects();
+
+        parent::tearDown();
     }
 
     public function testContainerMixinBuild()
@@ -109,6 +120,27 @@ final class ContainerMixinManifestTest extends TestCase
         $this->assertTrue($manifest->shouldRecompile());
 
         unlink('/tmp/ContainerMixin.php');
+    }
+
+    public function testShouldRecompileWhenTheProjectComposerFileChanged()
+    {
+        $projectPath = $this->createTemporaryProject(['name' => 'xefi/my-project']);
+
+        $container = new \Xefi\Faker\Container\Container(shouldBuildContainerMixin: false);
+        $manifest = new \Xefi\Faker\Manifests\ContainerMixinManifest($projectPath, $projectPath.'/ContainerMixin.php');
+        $manifest->build($container->getExtensionMethods(), $container->getExtensions());
+        touch($projectPath.'/vendor/composer/installed.json', time() - 1);
+        touch($projectPath.'/composer.json', time() - 1);
+
+        $this->assertFalse($manifest->shouldRecompile());
+
+        // Test on current time
+        touch($projectPath.'/composer.json');
+        $this->assertTrue($manifest->shouldRecompile());
+
+        // Test on future
+        touch($projectPath.'/composer.json', time() + 1);
+        $this->assertTrue($manifest->shouldRecompile());
     }
 
     public function testNoExtension()

--- a/tests/Unit/PackageManifestTest.php
+++ b/tests/Unit/PackageManifestTest.php
@@ -5,9 +5,20 @@ declare(strict_types=1);
 namespace Xefi\Faker\Tests\Unit;
 
 use Xefi\Faker\Manifests\PackageManifest;
+use Xefi\Faker\Tests\Support\Concerns\CreatesTemporaryProjects;
+use Xefi\Faker\Tests\Support\TestServiceProvider;
 
 final class PackageManifestTest extends TestCase
 {
+    use CreatesTemporaryProjects;
+
+    protected function tearDown(): void
+    {
+        $this->deleteTemporaryProjects();
+
+        parent::tearDown();
+    }
+
     public function testAssetLoading()
     {
         @unlink('/tmp/packages.php');
@@ -40,5 +51,197 @@ final class PackageManifestTest extends TestCase
         $this->assertTrue($manifest->shouldRecompile());
 
         unlink('/tmp/packages.php');
+    }
+
+    public function testProjectProvidersAreDiscovered()
+    {
+        $projectPath = $this->createTemporaryProject([
+            'name'  => 'xefi/my-project',
+            'extra' => [
+                'faker' => [
+                    'providers' => [TestServiceProvider::class],
+                ],
+            ],
+        ]);
+
+        $manifest = new PackageManifest($projectPath, $projectPath.'/packages.php');
+
+        $this->assertEquals(
+            [
+                'xefi/my-project' => [TestServiceProvider::class],
+            ],
+            $manifest->providers()
+        );
+    }
+
+    public function testProjectProvidersAreMergedWithTheInstalledPackagesOnes()
+    {
+        $projectPath = $this->createTemporaryProject(
+            [
+                'name'  => 'xefi/my-project',
+                'extra' => [
+                    'faker' => [
+                        'providers' => ['Xefi\Faker\Tests\Support\ProjectServiceProvider'],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'name'  => 'xefi/faker-number',
+                    'extra' => [
+                        'faker' => [
+                            'providers' => [TestServiceProvider::class],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $manifest = new PackageManifest($projectPath, $projectPath.'/packages.php');
+
+        $this->assertEquals(
+            [
+                'xefi/faker-number' => [TestServiceProvider::class],
+                'xefi/my-project'   => ['Xefi\Faker\Tests\Support\ProjectServiceProvider'],
+            ],
+            $manifest->providers()
+        );
+    }
+
+    public function testProjectProvidersAreKeyedByRootWhenTheProjectHasNoName()
+    {
+        $projectPath = $this->createTemporaryProject([
+            'extra' => [
+                'faker' => [
+                    'providers' => [TestServiceProvider::class],
+                ],
+            ],
+        ]);
+
+        $manifest = new PackageManifest($projectPath, $projectPath.'/packages.php');
+
+        $this->assertEquals(
+            [
+                'root' => [TestServiceProvider::class],
+            ],
+            $manifest->providers()
+        );
+    }
+
+    public function testProjectWithoutFakerConfigurationIsIgnored()
+    {
+        $projectPath = $this->createTemporaryProject(
+            [
+                'name'  => 'xefi/my-project',
+                'extra' => [
+                    'branch-alias' => ['dev-master' => '2.0.x-dev'],
+                ],
+            ],
+            [
+                [
+                    'name'  => 'xefi/faker-number',
+                    'extra' => [
+                        'faker' => [
+                            'providers' => [TestServiceProvider::class],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $manifest = new PackageManifest($projectPath, $projectPath.'/packages.php');
+
+        $this->assertEquals(
+            [
+                'xefi/faker-number' => [TestServiceProvider::class],
+            ],
+            $manifest->providers()
+        );
+    }
+
+    public function testProjectTakesPrecedenceOverAnInstalledPackageOfTheSameName()
+    {
+        $projectPath = $this->createTemporaryProject(
+            [
+                'name'  => 'xefi/faker-number',
+                'extra' => [
+                    'faker' => [
+                        'providers' => ['Xefi\Faker\Tests\Support\ProjectServiceProvider'],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'name'  => 'xefi/faker-number',
+                    'extra' => [
+                        'faker' => [
+                            'providers' => [TestServiceProvider::class],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $manifest = new PackageManifest($projectPath, $projectPath.'/packages.php');
+
+        $this->assertEquals(
+            [
+                'xefi/faker-number' => ['Xefi\Faker\Tests\Support\ProjectServiceProvider'],
+            ],
+            $manifest->providers()
+        );
+    }
+
+    public function testProjectWithoutComposerFileIsIgnored()
+    {
+        $projectPath = $this->createTemporaryProject(null, [
+            [
+                'name'  => 'xefi/faker-number',
+                'extra' => [
+                    'faker' => [
+                        'providers' => [TestServiceProvider::class],
+                    ],
+                ],
+            ],
+        ]);
+
+        $manifest = new PackageManifest($projectPath, $projectPath.'/packages.php');
+        $manifest->build();
+
+        $this->assertEquals(
+            [
+                'xefi/faker-number' => [
+                    'providers' => [TestServiceProvider::class],
+                ],
+            ],
+            require $projectPath.'/packages.php'
+        );
+    }
+
+    public function testShouldRecompileWhenTheProjectComposerFileChanged()
+    {
+        $projectPath = $this->createTemporaryProject([
+            'name'  => 'xefi/my-project',
+            'extra' => [
+                'faker' => [
+                    'providers' => [TestServiceProvider::class],
+                ],
+            ],
+        ]);
+
+        $manifest = new PackageManifest($projectPath, $projectPath.'/packages.php');
+        $manifest->build();
+        touch($projectPath.'/vendor/composer/installed.json', time() - 1);
+        touch($projectPath.'/composer.json', time() - 1);
+
+        $this->assertFalse($manifest->shouldRecompile());
+
+        // Test on current time
+        touch($projectPath.'/composer.json');
+        $this->assertTrue($manifest->shouldRecompile());
+
+        // Test on future
+        touch($projectPath.'/composer.json', time() + 1);
+        $this->assertTrue($manifest->shouldRecompile());
     }
 }


### PR DESCRIPTION
The auto-discovery feature of installed packages is nice, however it fails to discover project-local providers and extensions. This PR address this issue by reading the project `composer.json` file too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifest generation now includes project-level `extra.faker` configuration from the root Composer file.
  * Project configuration is supported under a default package entry when no package name is available.
  * Project-level settings take precedence over matching installed package configuration.

* **Bug Fixes**
  * Manifests now rebuild when the root Composer file changes.
  * Improved freshness checks help keep generated manifests synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->