### PR TITLE
Add the container as an extension constructor parameter to build "composable extensions".

### DIFF
--- a/src/Container/Traits/HasExtensions.php
+++ b/src/Container/Traits/HasExtensions.php
@@ -49,7 +49,7 @@ trait HasExtensions
      */
     protected function resolve(\Xefi\Faker\Extensions\Extension|string $extension): Container
     {
-        $instance = $extension instanceof Extension ? $extension : new $extension(new Randomizer());
+        $instance = $extension instanceof Extension ? $extension : new $extension(new Randomizer(), $this);
 
         // If the extension supports locale variations
         if (method_exists($instance, 'getLocale')) {

--- a/src/Extensions/Extension.php
+++ b/src/Extensions/Extension.php
@@ -4,14 +4,18 @@ namespace Xefi\Faker\Extensions;
 
 use Random\Randomizer;
 use ReflectionClass;
+use Xefi\Faker\Container\Container;
 
 class Extension
 {
     protected Randomizer $randomizer;
 
-    public function __construct(Randomizer $randomizer)
+    protected Container $container;
+
+    final public function __construct(Randomizer $randomizer, Container $container)
     {
         $this->randomizer = $randomizer;
+        $this->container = $container;
     }
 
     /**


### PR DESCRIPTION
With an access to the container into the extensions, we unlock the possibility to compose them.

```php
class MyPersonExtension extends Extension
{
    public function nameWithTitle(?string $gender = null): string
    {
        return sprintf('%s %s %s', $this->container->title($gender), $this->container->name($gender));
    }
}
```

This may be a trivial example, but I there is use-case where you have to combine things and its better to reuse existing logics.

BTW, I would like to discuss the need of all the traits (except `HasLocale`). Each of them only have their usage in the `Container` and therefore could be inlined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how extensions are created so they now receive the active container context during setup.
  * This helps extension-based features initialize more reliably and behave consistently across different locales and app states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->