### PR TITLE
Update inconsistent return type

### DIFF
--- a/src/Container/Traits/HasExtensions.php
+++ b/src/Container/Traits/HasExtensions.php
@@ -64,7 +64,7 @@ trait HasExtensions
      *
      * @param \Xefi\Faker\Extensions\Extension $extension
      *
-     * @return \Xefi\Faker\Extensions\Extension
+     * @return \Xefi\Faker\Container\Container
      */
     protected function addExtension(Extension $extension): Container
     {
@@ -96,7 +96,7 @@ trait HasExtensions
      *
      * @param \Xefi\Faker\Extensions\Extension $extension
      *
-     * @return \Xefi\Faker\Extensions\Extension
+     * @return \Xefi\Faker\Container\Container
      */
     protected function addLocaleExtension(Extension $extension): Container
     {


### PR DESCRIPTION
In `HasExtensions` trait, the resolve method return `Container` but underlying `addLocaleExtension` and `addExtension` annotations are about `Extension`

Fix those docblocks to align with code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected PHPDoc return annotations for container-extension registration methods.
  * Improved API documentation accuracy without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->