### PR TITLE
Update inconsistent phpdoc annotations

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -80,7 +80,7 @@ class Container
     /**
      * Set the container mixin manifest path.
      *
-     * @param string $manifestPath
+     * @param string $containerMixinManifestPath
      *
      * @return void
      */

--- a/src/Strategies/ValidStrategy.php
+++ b/src/Strategies/ValidStrategy.php
@@ -27,7 +27,7 @@ class ValidStrategy extends Strategy
      *
      * @param mixed $generatedValue
      *
-     * @return object
+     * @return bool
      */
     public function pass(mixed $generatedValue): bool
     {


### PR DESCRIPTION
Update some phpdoc annotations to align with code types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected PHPDoc parameter naming for improved clarity.
  * Updated the documented return type to accurately reflect the method’s boolean result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->